### PR TITLE
Add option for horizontal and card alignment to center

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   final List<Widget> fancyCards = [
@@ -54,7 +54,10 @@ class MyHomePage extends StatelessWidget {
         title: Text(title),
       ),
       body: StackedCardCarousel(
+        type: StackedCardCarouselType.cardsStack,
+        scrollDirection: Axis.horizontal,
         items: fancyCards,
+        cardAlignment: CardAlignment.center,
       ),
     );
   }
@@ -62,9 +65,9 @@ class MyHomePage extends StatelessWidget {
 
 class FancyCard extends StatelessWidget {
   const FancyCard({
-    Key key,
-    this.image,
-    this.title,
+    Key? key,
+    required this.image,
+    required this.title,
   }) : super(key: key);
 
   final Image image;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:
@@ -157,4 +157,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Stacked card carousel example
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:
@@ -143,4 +143,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This pull request offers two optional parameters:

- `scrollDirection` - defaults to Axis.vertical, but also allows for Axis.horizontal, which changes the direction of the PageView scroll direction, the parameter and alignment of the `Positioned` widget.
- `cardAlignment` - defaults to CardAlignment.start, but adds the option for CardAlignment.center.  Because if there's too many cards for the stacked version, the cards go offscreen.  This gives the option to always keep the top card centered.  Has no effect on the fading version.

Also switched to `Positioned` instead of `Positioned.fill`, otherwise the card gets width restricted when swiping to the edge of the screen. 

Fixes #1 